### PR TITLE
Update Biciraptor logo alt text and sizing

### DIFF
--- a/404.html
+++ b/404.html
@@ -180,7 +180,7 @@ Author: Kamleshyadav
 	<!--Menus Start-->
 	<div class="cy_menu_wrapper">
 		<div class="cy_logo_box">
-			<a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+			<a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
 		</div>
 		<div class="container">
 			<div class="row">
@@ -256,7 +256,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/about.html
+++ b/about.html
@@ -180,7 +180,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
         </div>
         <div class="container">
             <div class="row">
@@ -437,7 +437,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/blog.html
+++ b/blog.html
@@ -180,7 +180,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
         </div>
         <div class="container">
             <div class="row">
@@ -449,7 +449,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/blog_single.html
+++ b/blog_single.html
@@ -180,7 +180,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
         </div>
         <div class="container">
             <div class="row">
@@ -441,7 +441,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/cart.html
+++ b/cart.html
@@ -180,7 +180,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
         </div>
         <div class="container">
             <div class="row">
@@ -322,7 +322,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/checkout.html
+++ b/checkout.html
@@ -180,7 +180,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
         </div>
         <div class="container">
             <div class="row">
@@ -438,7 +438,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/contact.html
+++ b/contact.html
@@ -180,7 +180,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
         </div>
         <div class="container">
             <div class="row">
@@ -334,7 +334,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/css/style.css
+++ b/css/style.css
@@ -401,6 +401,9 @@ ul.cart_box li .cart_section a.cy_button{
 }
 .cy_logo_box img {
     display: inline-block;
+    max-height: 72px;
+    height: auto;
+    width: auto;
 }
 @media all and (-ms-high-contrast: none),
 (-ms-high-contrast: active) {

--- a/event.html
+++ b/event.html
@@ -180,7 +180,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
         </div>
         <div class="container">
             <div class="row">
@@ -396,7 +396,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/event_single.html
+++ b/event_single.html
@@ -180,7 +180,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
         </div>
         <div class="container">
             <div class="row">
@@ -466,7 +466,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/gallery.html
+++ b/gallery.html
@@ -180,7 +180,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
         </div>
         <div class="container">
             <div class="row">
@@ -383,7 +383,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
         </div>
         <div class="container">
             <div class="row">
@@ -1043,7 +1043,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/shop.html
+++ b/shop.html
@@ -181,7 +181,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"/></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/></a>
         </div>
         <div class="container">
             <div class="row">
@@ -643,7 +643,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>

--- a/shop_single.html
+++ b/shop_single.html
@@ -182,7 +182,7 @@ Author: Kamleshyadav
     <!--Menus Start-->
     <div class="cy_menu_wrapper">
         <div class="cy_logo_box">
-            <a href="index.html"><img src="images/logo.png" alt="logo" class="img-fluid"></a>
+            <a href="index.html"><img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"></a>
         </div>
         <div class="container">
             <div class="row">
@@ -645,7 +645,7 @@ Author: Kamleshyadav
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="footer-widget cy_footer_about">
-                        <img src="images/logo.png" alt="logo" class="img-fluid"/>
+                        <img src="images/logo.png" alt="Logo de Biciraptor" class="img-fluid"/>
                         <p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.</p>
                     </div>  
                 </div>


### PR DESCRIPTION
## Summary
- update the header and footer logo alt text across the main site pages to "Logo de Biciraptor"
- constrain the logo image sizing in CSS so the updated asset renders crisply

## Testing
- not run (static HTML/CSS updates only)


------
https://chatgpt.com/codex/tasks/task_b_690815290b4483209e6c0c6bd4fda9bb